### PR TITLE
Add the ability to assign $cert->sub

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -42,7 +42,9 @@ class Client
         $this->client->setDeveloperKey(array_get($config, 'developer_key', ''));
 
         // auth for service account
-        $this->auth($userEmail);
+        if (array_get($config, 'service.enable', false)) {
+            $this->auth($userEmail);
+        }
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,8 +18,9 @@ class Client
 
     /**
      * @param array $config
+     * @param string $userEmail
      */
-    public function __construct(array $config)
+    public function __construct(array $config, $userEmail='')
     {
         $this->config = $config;
 
@@ -41,9 +42,7 @@ class Client
         $this->client->setDeveloperKey(array_get($config, 'developer_key', ''));
 
         // auth for service account
-        if (array_get($config, 'service.enable', false)) {
-            $this->auth();
-        }
+        $this->auth($userEmail);
     }
 
     /**
@@ -81,12 +80,13 @@ class Client
     /**
      * Setup correct auth method based on type.
      *
+     * @param $userEmail
      * @return void
      */
-    protected function auth()
+    protected function auth($userEmail='')
     {
         // see (and use) if user has set Credentials
-        if ($this->useAssertCredentials()) {
+        if ($this->useAssertCredentials($userEmail)) {
             return;
         }
 
@@ -102,10 +102,10 @@ class Client
 
     /**
      * Determine and use credentials if user has set them.
-     *
+     * @param $userEmail
      * @return boolean used or not
      */
-    protected function useAssertCredentials()
+    protected function useAssertCredentials($userEmail='')
     {
         $account = array_get($this->config, 'service.account', '');
         if (!empty($account)) {
@@ -114,6 +114,9 @@ class Client
                 array_get($this->config, 'service.scopes', []),
                 file_get_contents(array_get($this->config, 'service.key', ''))
             );
+            if($userEmail){
+                $cert->sub=$userEmail;
+            }
             $this->client->setAssertionCredentials($cert);
 
             return true;


### PR DESCRIPTION
Added an optional parameter to the __constructor method. If this is set, $cert->sub=$userEmail is set in useAssertCredentials.