### PR TITLE
Delete version constraint for Laravel >= 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5",
+        "illuminate/support": "*",
         "google/apiclient": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
I don't want to update every six months. Want to delete version constraint?