### PR TITLE
Use namespaces from apiclient 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,6 @@ matrix:
   fast_finish: true
   include:
     - php: 7.2
-      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.2
-      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.3
-      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
-      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.4
-      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.4
-      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.2
       env: LARAVEL='6.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.2
       env: LARAVEL='6.*' COMPOSER_FLAGS='--prefer-stable'
@@ -30,6 +18,10 @@ matrix:
     - php: 7.4
       env: LARAVEL='6.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4
+      env: LARAVEL='6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 8.0
+      env: LARAVEL='6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 8.0
       env: LARAVEL='6.*' COMPOSER_FLAGS='--prefer-stable'
     - php: 7.2
       env: LARAVEL='7.*' COMPOSER_FLAGS='--prefer-lowest'
@@ -43,6 +35,26 @@ matrix:
       env: LARAVEL='7.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4
       env: LARAVEL='7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 8.0
+      env: LARAVEL='7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 8.0
+      env: LARAVEL='7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.4
+      env: LARAVEL='8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.4
+      env: LARAVEL='8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 8.0
+      env: LARAVEL='8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 8.0
+      env: LARAVEL='8.*' COMPOSER_FLAGS='--prefer-stable'
 
 before_install:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Get a service
 ```php
 $client = new PulkitJalan\Google\Client($config);
 
-// returns instance of \Google_Service_Storage
+// returns instance of \Google\Service\Storage
 $storage = $client->make('storage');
 
 // list buckets example
@@ -141,7 +141,7 @@ $storage->objects->get('bucket', 'object');
 
 Laravel Example:
 ```php
-// returns instance of \Google_Service_Storage
+// returns instance of \Google\Service\Storage
 $storage = Google::make('storage');
 
 // list buckets example

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Finally run `php artisan vendor:publish --provider="PulkitJalan\Google\GoogleSer
 
 #### Using an older version of PHP / Laravel?
 
-If you are on a PHP version below 7.2 or a Laravel version below 5.8 just use an older version of this package.
+If you are on a PHP version below 7.2 or a Laravel version below 6.0 just use an older version of this package.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ From [Google's upgrading document](https://github.com/google/google-api-php-clie
 > Note: P12s are deprecated in favor of service account JSON, which can be generated in the Credentials section of Google Developer Console.
 
 
-Get `Google_Client`
+Get `Google\Client`
 ```php
 $client = new PulkitJalan\Google\Client($config);
 $googleClient = $client->getClient();

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
-        "google/apiclient": "^2.4"
+        "illuminate/support": "^6.0|^7.0|^8.0",
+        "google/apiclient": "^2.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.3",
+        "phpunit/phpunit": "^9.3",
         "mockery/mockery": "^1.2.3"
     },
     "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,8 +2,8 @@
 
 namespace PulkitJalan\Google;
 
-use Google\Client as GoogleClient;
 use Illuminate\Support\Arr;
+use Google\Client as GoogleClient;
 use PulkitJalan\Google\Exceptions\UnknownServiceException;
 
 class Client
@@ -19,8 +19,8 @@ class Client
     protected $client;
 
     /**
-     * @param array $config
-     * @param string $userEmail
+     * @param  array  $config
+     * @param  string  $userEmail
      */
     public function __construct(array $config, $userEmail = '')
     {
@@ -62,8 +62,7 @@ class Client
     /**
      * Setter for the google client.
      *
-     * @param string $client
-     *
+     * @param  string  $client
      * @return self
      */
     public function setClient(GoogleClient $client)
@@ -76,11 +75,10 @@ class Client
     /**
      * Getter for the google service.
      *
-     * @param string $service
+     * @param  string  $service
+     * @return \Google_Service
      *
      * @throws \Exception
-     *
-     * @return \Google_Service
      */
     public function make($service)
     {
@@ -114,6 +112,7 @@ class Client
 
     /**
      * Determine and use credentials if user has set them.
+     *
      * @param $userEmail
      * @return bool used or not
      */
@@ -137,12 +136,11 @@ class Client
     /**
      * Magic call method.
      *
-     * @param string $method
-     * @param array  $parameters
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
      *
      * @throws \BadMethodCallException
-     *
-     * @return mixed
      */
     public function __call($method, $parameters)
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 
 namespace PulkitJalan\Google;
 
-use Google_Client;
+use Google\Client as GoogleClient;
 use Illuminate\Support\Arr;
 use PulkitJalan\Google\Exceptions\UnknownServiceException;
 
@@ -14,7 +14,7 @@ class Client
     protected $config;
 
     /**
-     * @var \Google_Client
+     * @var Google\Client
      */
     protected $client;
 
@@ -27,7 +27,7 @@ class Client
         $this->config = $config;
 
         // create an instance of the google client for OAuth2
-        $this->client = new Google_Client(Arr::get($config, 'config', []));
+        $this->client = new GoogleClient(Arr::get($config, 'config', []));
 
         // set application name
         $this->client->setApplicationName(Arr::get($config, 'application_name', ''));
@@ -52,7 +52,7 @@ class Client
     /**
      * Getter for the google client.
      *
-     * @return \Google_Client
+     * @return Google\Client
      */
     public function getClient()
     {
@@ -66,7 +66,7 @@ class Client
      *
      * @return self
      */
-    public function setClient(Google_Client $client)
+    public function setClient(GoogleClient $client)
     {
         $this->client = $client;
 
@@ -84,7 +84,7 @@ class Client
      */
     public function make($service)
     {
-        $service = 'Google_Service_'.ucfirst($service);
+        $service = 'Google\\Service\\'.ucfirst($service);
 
         if (class_exists($service)) {
             $class = new \ReflectionClass($service);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -16,7 +16,7 @@ class ClientTest extends TestCase
     {
         $client = Mockery::mock('PulkitJalan\Google\Client', [[]])->makePartial();
 
-        $this->assertInstanceOf('Google_Client', $client->getClient());
+        $this->assertInstanceOf('Google\Client', $client->getClient());
     }
 
     public function testClientGetterWithAdditionalConfig()
@@ -34,7 +34,7 @@ class ClientTest extends TestCase
     {
         $client = Mockery::mock('PulkitJalan\Google\Client', [[]])->makePartial();
 
-        $this->assertInstanceOf('Google_Service_Storage', $client->make('storage'));
+        $this->assertInstanceOf('Google\Service\Storage', $client->make('storage'));
     }
 
     public function testServiceMakeException()


### PR DESCRIPTION
`google/apiclient` and `google/apiclient-services` are both not PSR-4 and have proper namespaceing for there classes

Also trying to finish updates for php8

fix #55