### PR TITLE
L12 compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,23 +4,28 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
 
 jobs:
   test:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
         php: [8.3, 8.2, 8.1, 8.0]
-        laravel: ["^11.0", "^10.0", "^9.0", "^8.0"]
+        laravel: ['12.0', ^8.0, ^9.0, ^10.0, ^11.0]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - laravel: "^11.0"
+          - laravel: ^11.0
             php: 8.1
-          - laravel: "^11.0"
+          - laravel: ^11.0
             php: 8.0
-          - laravel: "^10.0"
+          - laravel: ^10.0
+            php: 8.0
+          - laravel: '12.0'
+            php: 8.1
+          - laravel: '12.0'
             php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
@@ -43,15 +48,15 @@ jobs:
 
       - name: Execute tests - with coverage
         id: test
-        if: matrix.dependency-version == 'prefer-stable' && matrix.php == 8.3 && matrix.laravel == '^11.0'
+        if: "matrix.dependency-version == 'prefer-stable' && matrix.php == 8.3 && matrix.laravel == '^11.0'"
         run: vendor/bin/pest --coverage
 
       - name: Execute tests - without coverage
-        if: steps.test.outcome == 'skipped'
+        if: "steps.test.outcome == 'skipped'"
         run: vendor/bin/pest
 
       - name: Upload coverage reports to Codecov
-        if: steps.test.outcome == 'success'
+        if: "steps.test.outcome == 'success'"
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.3, 8.2, 8.1, 8.0]
-        laravel: ['12.0', ^8.0, ^9.0, ^10.0, ^11.0]
+        laravel: [^12.0, ^11.0, ^10.0, ^9.0, ^8.0]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: ^11.0
@@ -23,9 +23,9 @@ jobs:
             php: 8.0
           - laravel: ^10.0
             php: 8.0
-          - laravel: '12.0'
+          - laravel: ^12.0
             php: 8.1
-          - laravel: '12.0'
+          - laravel: ^12.0
             php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,20 +13,38 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.2, 8.1, 8.0]
-        laravel: [^12.0, ^11.0, ^10.0, ^9.0, ^8.0]
-        dependency-version: [prefer-lowest, prefer-stable]
+        php:
+          - 8.4
+          - 8.3
+          - 8.2
+          - 8.1
+          - 8.0
+        laravel:
+          - ^12.0
+          - ^11.0
+          - ^10.0
+          - ^9.0
+          - ^8.0
+        dependency-version:
+          - prefer-lowest
+          - prefer-stable
         exclude:
+          - laravel: ^12.0
+            php: 8.1
+          - laravel: ^12.0
+            php: 8.0
           - laravel: ^11.0
             php: 8.1
           - laravel: ^11.0
             php: 8.0
           - laravel: ^10.0
             php: 8.0
-          - laravel: ^12.0
-            php: 8.1
-          - laravel: ^12.0
-            php: 8.0
+        include:
+          - with_coverage: false
+          - with_coverage: true
+            php: 8.3
+            laravel: ^11.0
+            dependency-version: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -46,17 +64,17 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
-      - name: Execute tests - with coverage
-        id: test
-        if: "matrix.dependency-version == 'prefer-stable' && matrix.php == 8.3 && matrix.laravel == '^11.0'"
-        run: vendor/bin/pest --coverage
-
       - name: Execute tests - without coverage
-        if: "steps.test.outcome == 'skipped'"
+        if: matrix.with_coverage == false
         run: vendor/bin/pest
 
+      - name: Execute tests - with coverage
+        id: test
+        if: matrix.with_coverage == true
+        run: vendor/bin/pest --coverage
+
       - name: Upload coverage reports to Codecov
-        if: "steps.test.outcome == 'success'"
+        if: matrix.with_coverage == true
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,7 @@
                 "Google": "PulkitJalan\\Google\\Facades\\Google"
             }
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": ">=8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "google/apiclient": "^2.16"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",
-        "pestphp/pest": "^1.20|^2.0"
+        "pestphp/pest": "^1.20|^2.0|^3.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request includes updates to the workflow configuration and dependency management to support newer versions of PHP and Laravel, as well as improvements to the test execution process.

### Workflow Configuration Updates:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L7-R47): Updated the PHP and Laravel versions matrix to include PHP 8.4 and Laravel ^12.0. The matrix now also includes an option to run tests with or without coverage.
* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R67-R77): Modified the test execution steps to conditionally run tests with or without coverage based on the matrix configuration.

### Dependency Management Updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L18-R23): Added support for Laravel ^12.0 and Pest ^3.7 in the `require` and `require-dev` sections, respectively.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L53-R55): Set the minimum stability to "dev" and preferred stability to true to ensure the use of stable versions when available.